### PR TITLE
debug ifstream failbit

### DIFF
--- a/src/fileinteraction.cpp
+++ b/src/fileinteraction.cpp
@@ -69,8 +69,7 @@ TuringaKey readTuringaKey(const char* filename) {
 
   Byte* rotorShifts = (Byte*)malloc(MAX_KEYLENGTH);
   myfile.read((char*)rotorShifts,keylength);
-  std::cout<<std::ifstream::failbit<<std::endl;
-  //assert(std::ifstream::failbit == 1 && "Couldn't read correctly");
+  assert(myfile.fail() == 0 && "Couldn't read correctly!");
   const TuringaKey key{direction, keylength, rotorNames, rotorShifts, fileShift};
 
   std::cout << timestamp(current_duration()) << "Turinga key has been read.\n";
@@ -88,6 +87,7 @@ void writeTuringaKey(const std::string filename, const TuringaKey& key) {
   }
   myfile << " " << key.fileShift << std::endl;
   myfile.write((char*)key.rotorShifts,key.length);
+  assert(myfile.fail() == 0 && "Couldn't write correctly!");
   std::cout << timestamp(current_duration()) << "Turinga key has been written to <" << filename
             << ">.\n";
 }


### PR DESCRIPTION
The assertion is uncommented at the moment. The std::ifstream::failbit was set to 4 in all test cases.